### PR TITLE
Harden baseline behavior and configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build app image
+        run: docker compose build
+
+      - name: Run test suite
+        env:
+          CLOUDINARY_CLOUD_NAME: test-cloud
+          CLOUDINARY_API_KEY: test-key
+          CLOUDINARY_API_SECRET: test-secret
+        run: docker compose run --rm -e RAILS_ENV=test app bash -lc "bundle exec rake db:create db:schema:load && bundle exec rspec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,19 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Build app image
+        run: docker compose build
+
+      - name: Run RuboCop
+        run: docker compose run --rm app bash -lc "bundle exec rubocop --lint --force-exclusion app config db lib spec"
+
   test:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This changelog was reconstructed from the repository commit history because the 
 
 ## 2026-03-15
 
+### Baseline hardening
+
+- Moved Cloudinary configuration to environment variables instead of committing plaintext credentials.
+- Replaced factory-based seeding with explicit records in `db/seeds.rb`.
+- Added focused feature coverage for sign-up, sign-in, recipe updates, and the login requirement for recipe creation.
+- Hardened recipe image rendering so pages still load when Cloudinary is not configured and no photo is present.
+- Added a GitHub Actions workflow that runs the Docker-based test suite.
+
 ### Dependency cleanup
 
 - Removed app-level usage of `responders` and replaced `respond_with` controller flows with explicit redirects and renders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This changelog was reconstructed from the repository commit history because the 
 - Replaced factory-based seeding with explicit records in `db/seeds.rb`.
 - Added focused feature coverage for sign-up, sign-in, recipe updates, and the login requirement for recipe creation.
 - Hardened recipe image rendering so pages still load when Cloudinary is not configured and no photo is present.
-- Added a GitHub Actions workflow that runs the Docker-based test suite.
+- Added a GitHub Actions workflow that runs Docker-based RuboCop linting and the test suite.
 
 ### Dependency cleanup
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ If needed:
 colima start
 ```
 
+### Configuration
+
+Cloudinary credentials are no longer committed in the repository. Export these variables before starting the app if you want upload integration configured:
+
+```bash
+export CLOUDINARY_CLOUD_NAME=your-cloud-name
+export CLOUDINARY_API_KEY=your-api-key
+export CLOUDINARY_API_SECRET=your-api-secret
+```
+
 ### Build the app
 
 ```bash
@@ -92,6 +102,6 @@ The Docker image uses Ruby `2.3.8` and archived Debian package sources because t
 
 ## Notes and Caveats
 
-- `config/cloudinary.yml` contains hard-coded credentials and should be treated as sensitive configuration.
-- `db/seeds.rb` uses `FactoryBot`, which is acceptable for local/dev use here because the Docker image installs the development and test gems, but it is not a production-grade seed strategy.
+- `config/cloudinary.yml` now reads credentials from environment variables rather than committed secrets.
+- `db/seeds.rb` creates explicit records and no longer depends on test factories.
 - The app is functionally small and spec coverage is high, but authorization in controllers is still hand-rolled rather than centralized.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  def recipe_image(recipe, options = {})
+    return unless recipe.photo?
+
+    image_tag(recipe.photo_url, options)
+  end
 end

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -1,5 +1,5 @@
 <h4><%= link_to recipe.name, recipe %></h4><br>
-<%= image_tag(recipe.photo_url, alt: recipe.name ) %>
+<%= recipe_image(recipe, alt: recipe.name) %>
 <p><strong>Kitchen:</strong> <%= recipe.kitchen.name %></p>
 <p><strong>Food type:</strong> <%= recipe.food_type.name%></p>
 <p><strong>Preference:</strong> <%= recipe.preference.title %></p>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -4,7 +4,7 @@
     <div id="content" class="col-xs-12 col-sm-6 col-m-8">
       <h2><%= @recipe.name %></h2>
       <hr>
-      <%= image_tag(@recipe.photo_url, alt: @recipe.name ) %>
+      <%= recipe_image(@recipe, alt: @recipe.name) %>
       <p><strong>Kitchen:</strong> <%= @recipe.kitchen.name %></p>
       <p><strong>Food type:</strong> <%= @recipe.food_type.name%></p>
       <p><strong>Preference:</strong> <%= @recipe.preference.title %></p>

--- a/config/cloudinary.yml
+++ b/config/cloudinary.yml
@@ -1,19 +1,19 @@
 ---
 development:
-  cloud_name: http-espacogeek-com
-  api_key: '337342162424449'
-  api_secret: hGxSwzCCKCwB4CIZWv-IyuGCtPo
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
   enhance_image_tag: true
   static_image_support: false
 production:
-  cloud_name: http-espacogeek-com
-  api_key: '337342162424449'
-  api_secret: hGxSwzCCKCwB4CIZWv-IyuGCtPo
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
   enhance_image_tag: true
   static_image_support: true
 test:
-  cloud_name: http-espacogeek-com
-  api_key: '337342162424449'
-  api_secret: hGxSwzCCKCwB4CIZWv-IyuGCtPo
+  cloud_name: <%= ENV['CLOUDINARY_CLOUD_NAME'] %>
+  api_key: <%= ENV['CLOUDINARY_API_KEY'] %>
+  api_secret: <%= ENV['CLOUDINARY_API_SECRET'] %>
   enhance_image_tag: true
   static_image_support: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,27 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+kitchen = Kitchen.find_or_create_by!(name: 'Japonesa')
+food_type = FoodType.find_or_create_by!(name: 'Salgado')
+preference = Preference.find_or_create_by!(title: 'Sem lactose')
 
-kitchen = FactoryBot.create(:kitchen)
-food_type = FactoryBot.create(:food_type)
-preference = FactoryBot.create(:preference)
+admin = User.find_or_initialize_by(email: 'admin@socialrecipes.local')
+admin.assign_attributes(
+  name: 'Social Recipes Admin',
+  location: 'Sao Paulo',
+  twitter: 'socialrecipes',
+  facebook: 'socialrecipes',
+  password: 'rubyonrails',
+  password_confirmation: 'rubyonrails',
+  admin: true
+)
+admin.save!
+
+Recipe.find_or_create_by!(name: 'Temaki de Salmao Completo') do |recipe|
+  recipe.kitchen = kitchen
+  recipe.food_type = food_type
+  recipe.preference = preference
+  recipe.user = admin
+  recipe.servings = 4
+  recipe.cook_time = 45
+  recipe.difficulty = 'Medio'
+  recipe.ingredients = 'Salmao, alga, cream cheese e cebolinha.'
+  recipe.steps = 'Corte a alga, monte o recheio e enrole o temaki.'
+end

--- a/spec/user/user_filter_home_recipes_spec.rb
+++ b/spec/user/user_filter_home_recipes_spec.rb
@@ -8,7 +8,7 @@ feature 'User filter recipes at homepage' do
     kitchen2 = FactoryBot.create(:kitchen, name: 'Italiana')
     preference = FactoryBot.create(:preference)
     preference2 = FactoryBot.create(:preference, title: 'Vegetariana')
-    recipe = FactoryBot.create(:recipe)
+    FactoryBot.create(:recipe)
 
     visit root_path
 

--- a/spec/user/user_keeps_your_recipes_spec.rb
+++ b/spec/user/user_keeps_your_recipes_spec.rb
@@ -6,7 +6,6 @@ feature 'User keeps your recipes' do
     user2 = FactoryBot.create(:user, email: 'giga@gmail.com', admin: false)
     recipe = FactoryBot.create(:recipe, user_id: user.id)
     recipe2 = FactoryBot.create(:recipe, user_id: user2.id)
-    food_type = FactoryBot.build(:food_type)
 
     visit new_user_session_path
 

--- a/spec/user/user_signs_in_spec.rb
+++ b/spec/user/user_signs_in_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+feature 'User signs in' do
+  scenario 'successfully' do
+    user = FactoryBot.create(:user, admin: false)
+
+    visit new_user_session_path
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    click_on 'Log in'
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content(user.email)
+  end
+end

--- a/spec/user/user_signs_up_spec.rb
+++ b/spec/user/user_signs_up_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature 'User signs up' do
+  scenario 'successfully' do
+    visit new_user_registration_path
+
+    fill_in 'Name', with: 'Ana Paula'
+    fill_in 'Location', with: 'Sao Paulo'
+    fill_in 'Twitter', with: 'anapaula'
+    fill_in 'Facebook', with: 'anapaula'
+    fill_in 'Email', with: 'ana@example.com'
+    fill_in 'Password', with: 'rubyonrails'
+    fill_in 'Password confirmation', with: 'rubyonrails'
+
+    click_on 'Sign up'
+
+    user = User.find_by(email: 'ana@example.com')
+
+    expect(user).not_to be_nil
+    expect(user.name).to eq 'Ana Paula'
+    expect(user.location).to eq 'Sao Paulo'
+    expect(user.twitter).to eq 'anapaula'
+    expect(user.facebook).to eq 'anapaula'
+    expect(page).to have_content(user.email)
+  end
+end

--- a/spec/user/user_updates_recipe_spec.rb
+++ b/spec/user/user_updates_recipe_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'User updates own recipe' do
+  scenario 'successfully' do
+    user = FactoryBot.create(:user, admin: false)
+    recipe = FactoryBot.create(:recipe, user: user)
+
+    login_user(user)
+
+    visit edit_recipe_path(recipe)
+
+    fill_in 'Name', with: 'Temaki Especial'
+    fill_in 'Servings', with: '6'
+    fill_in 'Ingredients', with: 'Salmao, arroz e cebolinha.'
+    fill_in 'Steps', with: 'Monte o recheio e finalize o temaki.'
+
+    click_on 'Salvar Receita'
+
+    expect(page).to have_content 'Temaki Especial'
+    expect(page).to have_content '6'
+    expect(page).to have_content 'Salmao, arroz e cebolinha.'
+    expect(page).to have_content 'Monte o recheio e finalize o temaki.'
+  end
+end

--- a/spec/user/user_visits_home_spec.rb
+++ b/spec/user/user_visits_home_spec.rb
@@ -2,26 +2,18 @@ require 'rails_helper'
 
 feature 'Home show recipes' do
   scenario 'successfully' do
-    user = FactoryBot.create(:user)
-    food_type = FactoryBot.create(:food_type)
-    kitchen = FactoryBot.create(:kitchen)
-    preference = FactoryBot.create(:preference)
     recipe = FactoryBot.create(:recipe)
 
     visit root_path
 
     expect(page).to have_content recipe.name
-    expect(page).to have_content kitchen.name
-    expect(page).to have_content food_type.name
-    expect(page).to have_content preference.title
+    expect(page).to have_content recipe.kitchen.name
+    expect(page).to have_content recipe.food_type.name
+    expect(page).to have_content recipe.preference.title
     expect(page).to have_content recipe.difficulty
   end
 
   scenario 'and visit recipes details' do
-    user = FactoryBot.create(:user)
-    food_type = FactoryBot.create(:food_type)
-    kitchen = FactoryBot.create(:kitchen)
-    preference = FactoryBot.create(:preference)
     recipe = FactoryBot.create(:recipe)
 
     visit root_path

--- a/spec/user/visitor_must_sign_in_to_create_recipe_spec.rb
+++ b/spec/user/visitor_must_sign_in_to_create_recipe_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+feature 'Visitor must sign in to create recipes' do
+  scenario 'when opening the new recipe page' do
+    visit new_recipe_path
+
+    expect(current_path).to eq new_user_session_path
+    expect(page).to have_content 'Log in'
+  end
+end


### PR DESCRIPTION
## Summary
- move Cloudinary configuration to environment variables and replace factory-based seeds with explicit records
- add focused regression coverage for sign-up, sign-in, recipe updates, and the login requirement for recipe creation
- add Docker-based GitHub Actions CI and update the changelog

## Verification
- docker-compose run --rm -e RAILS_ENV=test app bash -lc "bundle exec rake db:create db:schema:load && bundle exec rspec"
- result: 30 examples, 0 failures