### PR TITLE
Raise coverage for uploads, social actions, and admin CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This changelog was reconstructed from the repository commit history because the 
 
 ## 2026-03-16
 
+### Test hardening
+
+- Added deeper upload coverage for recipe photos, including preserving an existing attachment on edit and replacing it with a new file.
+- Added request coverage for recipe favorites and kitchen likes so repeated POST and DELETE calls no longer toggle or duplicate associations unexpectedly.
+- Added request coverage for admin-only taxonomy creation, including unauthenticated redirects, non-admin rejection, and invalid form submissions.
+- Added presence validations to kitchens, food types, and preferences so invalid admin submissions now fail consistently instead of silently creating blank records.
+
 ### Ruby 4.0 evaluation and adoption
 
 - Evaluated the Rails `8.1.2` baseline on Ruby `4.0.1` and adopted the runtime bump after verifying app boot, linting, Zeitwerk, and the full Docker-based test suite.

--- a/app/controllers/kitchens_controller.rb
+++ b/app/controllers/kitchens_controller.rb
@@ -29,14 +29,12 @@ class KitchensController < ApplicationController
   end
 
   def like
-    unless @kitchen.likers.exists?(current_user.id)
-      @kitchen.likers << current_user
-      @kitchen.save
-      redirect_to @kitchen, notice: 'Cozinha adicionada as favoritas!'
-    else
-      @kitchen.likers.delete(current_user)
-      @kitchen.save
+    if request.delete?
+      @kitchen.likers.delete(current_user) if @kitchen.likers.exists?(current_user.id)
       redirect_to @kitchen, notice: 'Cozinha removida das favoritas!'
+    else
+      @kitchen.likers << current_user unless @kitchen.likers.exists?(current_user.id)
+      redirect_to @kitchen, notice: 'Cozinha adicionada as favoritas!'
     end
   end
 

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -48,12 +48,12 @@ class RecipesController < ApplicationController
   end
 
   def favorite
-    unless @recipe.fans.exists?(current_user.id)
-      add_fan
-      redirect_to @recipe, notice: 'Receita adicionada as favoritas!'
-    else
-      remove_fan
+    if request.delete?
+      remove_fan if @recipe.fans.exists?(current_user.id)
       redirect_to @recipe, notice: 'Receita removida das favoritas!'
+    else
+      add_fan unless @recipe.fans.exists?(current_user.id)
+      redirect_to @recipe, notice: 'Receita adicionada as favoritas!'
     end
   end
 

--- a/app/models/food_type.rb
+++ b/app/models/food_type.rb
@@ -1,3 +1,5 @@
 class FoodType < ApplicationRecord
   has_many :recipes
+
+  validates :name, presence: true
 end

--- a/app/models/kitchen.rb
+++ b/app/models/kitchen.rb
@@ -1,4 +1,6 @@
 class Kitchen < ApplicationRecord
   has_many :recipes
   has_and_belongs_to_many :likers, class_name: :User, join_table: :kitchens_users
+
+  validates :name, presence: true
 end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,3 +1,5 @@
 class Preference < ApplicationRecord
   has_many :recipes
+
+  validates :title, presence: true
 end

--- a/spec/fixtures/files/recipe-photo-replacement.svg
+++ b/spec/fixtures/files/recipe-photo-replacement.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+  <rect width="120" height="120" fill="#f97316" />
+  <circle cx="60" cy="60" r="34" fill="#1f2937" />
+</svg>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -37,6 +38,7 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
   config.include ModelMacros
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/admin_crud_spec.rb
+++ b/spec/requests/admin_crud_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin CRUD', type: :request do
+  describe 'POST /kitchens' do
+    let(:admin) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user, admin: false) }
+
+    it 'redirects unauthenticated users to sign in' do
+      expect do
+        post kitchens_path, params: { kitchen: { name: 'Brasileira' } }
+      end.not_to change(Kitchen, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'rejects non-admin users' do
+      sign_in user
+
+      expect do
+        post kitchens_path, params: { kitchen: { name: 'Brasileira' } }
+      end.not_to change(Kitchen, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 're-renders the form for invalid admin submissions' do
+      sign_in admin
+
+      expect do
+        post kitchens_path, params: { kitchen: { name: '' } }
+      end.not_to change(Kitchen, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Warning! All fields are mandatory.')
+      expect(response.body).to include('Name')
+    end
+  end
+
+  describe 'POST /food_types' do
+    let(:admin) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user, admin: false) }
+
+    it 'redirects unauthenticated users to sign in' do
+      expect do
+        post food_types_path, params: { food_type: { name: 'Sobremesa' } }
+      end.not_to change(FoodType, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'rejects non-admin users' do
+      sign_in user
+
+      expect do
+        post food_types_path, params: { food_type: { name: 'Sobremesa' } }
+      end.not_to change(FoodType, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 're-renders the form for invalid admin submissions' do
+      sign_in admin
+
+      expect do
+        post food_types_path, params: { food_type: { name: '' } }
+      end.not_to change(FoodType, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Warning! All fields are mandatory.')
+      expect(response.body).to include('Name')
+    end
+  end
+
+  describe 'POST /preferences' do
+    let(:admin) { FactoryBot.create(:user) }
+    let(:user) { FactoryBot.create(:user, admin: false) }
+
+    it 'redirects unauthenticated users to sign in' do
+      expect do
+        post preferences_path, params: { preference: { title: 'Sem Lactose' } }
+      end.not_to change(Preference, :count)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it 'rejects non-admin users' do
+      sign_in user
+
+      expect do
+        post preferences_path, params: { preference: { title: 'Sem Lactose' } }
+      end.not_to change(Preference, :count)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 're-renders the form for invalid admin submissions' do
+      sign_in admin
+
+      expect do
+        post preferences_path, params: { preference: { title: '' } }
+      end.not_to change(Preference, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Warning! All fields are mandatory.')
+      expect(response.body).to include('Title')
+    end
+  end
+end

--- a/spec/requests/social_actions_spec.rb
+++ b/spec/requests/social_actions_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Social actions', type: :request do
+  let(:user) { FactoryBot.create(:user, admin: false) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'recipe favorites' do
+    let(:recipe) { FactoryBot.create(:recipe) }
+
+    it 'adds a favorite only once even if the create endpoint is posted twice' do
+      post favorite_recipe_path(recipe)
+      post favorite_recipe_path(recipe)
+
+      expect(response).to redirect_to(recipe_path(recipe))
+      expect(recipe.reload.fans).to contain_exactly(user)
+    end
+
+    it 'keeps the favorite removed when the delete endpoint is called twice' do
+      post favorite_recipe_path(recipe)
+
+      delete favorite_recipe_path(recipe)
+      delete favorite_recipe_path(recipe)
+
+      expect(response).to redirect_to(recipe_path(recipe))
+      expect(recipe.reload.fans).to be_empty
+    end
+  end
+
+  describe 'kitchen likes' do
+    let(:kitchen) { FactoryBot.create(:kitchen) }
+
+    it 'adds a like only once even if the create endpoint is posted twice' do
+      post like_kitchen_path(kitchen)
+      post like_kitchen_path(kitchen)
+
+      expect(response).to redirect_to(kitchen_path(kitchen))
+      expect(kitchen.reload.likers).to contain_exactly(user)
+    end
+
+    it 'keeps the like removed when the delete endpoint is called twice' do
+      post like_kitchen_path(kitchen)
+
+      delete like_kitchen_path(kitchen)
+      delete like_kitchen_path(kitchen)
+
+      expect(response).to redirect_to(kitchen_path(kitchen))
+      expect(kitchen.reload.likers).to be_empty
+    end
+  end
+end

--- a/spec/user/user_uploads_recipe_photo_spec.rb
+++ b/spec/user/user_uploads_recipe_photo_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 feature 'User uploads a recipe photo' do
+  let(:original_photo_path) { Rails.root.join('spec/fixtures/files/recipe-photo.svg') }
+  let(:replacement_photo_path) { Rails.root.join('spec/fixtures/files/recipe-photo-replacement.svg') }
+
   scenario 'successfully' do
     user = FactoryBot.create(:user)
     kitchen = FactoryBot.create(:kitchen)
@@ -29,5 +32,44 @@ feature 'User uploads a recipe photo' do
 
     expect(page).to have_selector("img[alt='Temaki especial']")
     expect(Recipe.last.photo).to be_attached
+  end
+
+  scenario 'and keeps the existing photo when updating recipe details only' do
+    user = FactoryBot.create(:user, admin: false)
+    recipe = FactoryBot.create(:recipe, user: user)
+    recipe.photo.attach(io: File.open(original_photo_path), filename: 'recipe-photo.svg',
+                        content_type: 'image/svg+xml')
+    original_blob_id = recipe.photo.blob_id
+
+    login_user(user)
+
+    visit edit_recipe_path(recipe)
+    fill_in 'Name', with: 'Temaki atualizado'
+
+    click_on 'Salvar Receita'
+
+    expect(page).to have_content('Temaki atualizado')
+    expect(recipe.reload.photo).to be_attached
+    expect(recipe.photo.blob_id).to eq(original_blob_id)
+  end
+
+  scenario 'and replaces the existing photo when uploading a new one on edit' do
+    user = FactoryBot.create(:user, admin: false)
+    recipe = FactoryBot.create(:recipe, user: user)
+    recipe.photo.attach(io: File.open(original_photo_path), filename: 'recipe-photo.svg',
+                        content_type: 'image/svg+xml')
+    original_blob_id = recipe.photo.blob_id
+
+    login_user(user)
+
+    visit edit_recipe_path(recipe)
+    fill_in 'Name', with: 'Temaki com nova foto'
+    attach_file 'Photo', replacement_photo_path
+
+    click_on 'Salvar Receita'
+
+    expect(page).to have_content('Temaki com nova foto')
+    expect(recipe.reload.photo).to be_attached
+    expect(recipe.photo.blob_id).not_to eq(original_blob_id)
   end
 end


### PR DESCRIPTION
## Summary
- add deeper upload coverage for preserving and replacing attached recipe photos
- add request coverage for favorites and likes so repeated POST and DELETE calls do not toggle or duplicate associations
- add request coverage for admin-only taxonomy creation, including unauthenticated, non-admin, and invalid submission paths
- add missing presence validations for kitchens, food types, and preferences so invalid admin submissions fail consistently
- update the changelog

## Verification
- docker-compose run --rm app bash -lc "bundle exec rubocop --lint --force-exclusion app config db lib spec"
- docker-compose run --rm -e RAILS_ENV=test app bash -lc "bundle exec rails db:environment:set RAILS_ENV=test && bundle exec rake db:drop db:create db:schema:load && bundle exec rspec"
- docker-compose up -d --force-recreate
- browser smoke check on /, /users/sign_in, and /users/sign_up

## Result
- 46 examples, 0 failures